### PR TITLE
add-remotes: Skip remotes whose name would derive an invalid refspec configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -14,6 +15,9 @@ var rootCmd = &cobra.Command{
 Manage a local git repository with many disjoint commit graphs fetched from many
 independent remotes. This allows all git objects from all the repos to be stored
 in a common local git database for bulk analysis and queries.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		pushInContext(cmd)
+	},
 }
 
 func Execute() {
@@ -21,4 +25,19 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+type cmdValueKey struct{}
+
+func pushInContext(cmd *cobra.Command) {
+	cmd.SetContext(context.WithValue(cmd.Context(), cmdValueKey{}, cmd))
+}
+
+func commandFrom(ctx context.Context) *cobra.Command {
+	v := ctx.Value(cmdValueKey{})
+	result, ok := v.(*cobra.Command)
+	if !ok {
+		return nil
+	}
+	return result
 }


### PR DESCRIPTION
Fixes #1